### PR TITLE
Minimal separation of models by language. Add update_embeddings() to data ingestion. update API config

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -42,7 +42,7 @@ app = get_application()
 logger.info("Open http://127.0.0.1:8000/docs to see Swagger API Documentation.")
 logger.info(
     """
-Or just try it out directly: curl --request POST --url 'http://127.0.0.1:8000/models/1/doc-qa' --data '{"questions": ["Who is the father of Arya Starck?"]}'
+Or just try it out directly: curl --request POST --url 'http://127.0.0.1:8000/models/1/faq-qa' --data '{"questions": ["What are symptoms?"]}'
 """
 )
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -2,7 +2,7 @@ import ast
 import os
 
 # Resources / Computation
-USE_GPU = os.getenv("USE_GPU", "False").lower() == "true"
+USE_GPU = os.getenv("USE_GPU", "True").lower() == "true"
 MAX_PROCESSES = int(os.getenv("MAX_PROCESSES", 4))
 BATCHSIZE = int(os.getenv("BATCHSIZE", 50))
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -2,7 +2,7 @@ import ast
 import os
 
 # Resources / Computation
-USE_GPU = os.getenv("USE_GPU", "True").lower() == "true"
+USE_GPU = os.getenv("USE_GPU", "False").lower() == "true"
 MAX_PROCESSES = int(os.getenv("MAX_PROCESSES", 4))
 BATCHSIZE = int(os.getenv("BATCHSIZE", 50))
 
@@ -17,7 +17,9 @@ MAX_SEQ_LEN = int(os.getenv("MAX_SEQ_LEN", 256))
 
 # Retriever
 DEFAULT_TOP_K_RETRIEVER = int(os.getenv("DEFAULT_TOP_K_RETRIEVER", 10))
-EMBEDDING_MODEL_PATH = os.getenv("EMBEDDING_MODEL_PATH", None)
+EMBEDDING_MODEL_PATH = os.getenv("EMBEDDING_MODEL_PATH", "deepset/sentence_bert")
+EMBEDDING_POOLING_STRATEGY = os.getenv("EMBEDDING_POOLING_STRATEGY", "reduce_mean")
+EMBEDDING_EXTRACTION_LAYER = int(os.getenv("EMBEDDING_EXTRACTION_LAYER", -2))
 
 # Database access
 DB_HOST = os.getenv("DB_HOST", "localhost")
@@ -26,11 +28,11 @@ DB_PW = os.getenv("DB_PW", "")
 DB_INDEX = os.getenv("DB_INDEX", "document")
 DB_INDEX_FEEDBACK = os.getenv("DB_INDEX", "feedback")
 ES_CONN_SCHEME = os.getenv("ES_CONN_SCHEME", "http")
-TEXT_FIELD_NAME = os.getenv("TEXT_FIELD_NAME", "text")
-SEARCH_FIELD_NAME = os.getenv("SEARCH_FIELD_NAME", "text")
-EMBEDDING_FIELD_NAME = os.getenv("EMBEDDING_FIELD_NAME", None)
+TEXT_FIELD_NAME = os.getenv("TEXT_FIELD_NAME", "answer")
+SEARCH_FIELD_NAME = os.getenv("SEARCH_FIELD_NAME", "question")
+EMBEDDING_FIELD_NAME = os.getenv("EMBEDDING_FIELD_NAME", "question_emb")
 EMBEDDING_DIM = os.getenv("EMBEDDING_DIM", None)
-EXCLUDE_META_DATA_FIELDS = os.getenv("EXCLUDE_META_DATA_FIELDS", None)
+
+EXCLUDE_META_DATA_FIELDS = os.getenv("EXCLUDE_META_DATA_FIELDS", "['question_emb']")
 if EXCLUDE_META_DATA_FIELDS:
     EXCLUDE_META_DATA_FIELDS = ast.literal_eval(EXCLUDE_META_DATA_FIELDS)
-EMBEDDING_MODEL_PATH = os.getenv("EMBEDDING_MODEL_PATH", None)

--- a/backend/controller/model.py
+++ b/backend/controller/model.py
@@ -23,6 +23,8 @@ from backend.config import (
     EMBEDDING_FIELD_NAME,
     EXCLUDE_META_DATA_FIELDS,
     EMBEDDING_MODEL_PATH,
+    EMBEDDING_POOLING_STRATEGY,
+    EMBEDDING_EXTRACTION_LAYER,
     READER_MODEL_PATH,
     BATCHSIZE,
     USE_GPU,
@@ -58,7 +60,8 @@ document_store = ElasticsearchDocumentStore(
 )
 
 
-retriever = ElasticsearchRetriever(document_store=document_store, embedding_model=EMBEDDING_MODEL_PATH, gpu=USE_GPU)
+retriever = ElasticsearchRetriever(document_store=document_store, embedding_model=EMBEDDING_MODEL_PATH, gpu=USE_GPU,
+                                   pooling_strategy=EMBEDDING_POOLING_STRATEGY, emb_extraction_layer=EMBEDDING_EXTRACTION_LAYER)
 
 if READER_MODEL_PATH:
     # needed for extractive QA
@@ -149,7 +152,7 @@ def ask(model_id: int, request: Query):
 
 
 @router.post("/models/{model_id}/faq-qa", response_model=Response, response_model_exclude_unset=True)
-def ask(model_id: int, request: Query):
+def ask_faq(model_id: int, request: Query):
     t1 = time.time()
     finder = FINDERS.get(model_id, None)
     if not finder:

--- a/backend/data_ingestion.py
+++ b/backend/data_ingestion.py
@@ -3,44 +3,76 @@ from haystack import Finder
 from haystack.database.elasticsearch import ElasticsearchDocumentStore
 from haystack.retriever.elasticsearch import ElasticsearchRetriever
 
-MODEL = "bert-base-uncased"
-GPU = False
+def index_new_docs(document_store, retriever):
+    # Get dataframe with questions, answers and some metadata
+    df = pd.read_csv("data/faqs/faq_covidbert.csv")
+    df.fillna(value="", inplace=True)
 
-document_store = ElasticsearchDocumentStore(
-    host="localhost",
-    username="",
-    password="",
-    index="document",
-    text_field="answer",
-    embedding_field="question_emb",
-    embedding_dim=768,
-    excluded_meta_data=["question_emb"],
-)
-
-retriever = ElasticsearchRetriever(document_store=document_store, embedding_model=MODEL, gpu=GPU)
-
-# Get dataframe with questions, answers and some metadata
-df = pd.read_csv("data/faqs/faq_covidbert.csv")
-df.fillna(value="", inplace=True)
-
-# Index to ES
-if document_store.get_document_count() == 0:
-    docs_to_index = []
-    doc_id = 1
-    for idx, row in df.iterrows():
-        d = row.to_dict()
-        d = {k: v.strip() for k, v in d.items()}
-        d["document_id"] = idx
-        # add embedding
-        question_embedding = retriever.create_embedding(row["question"])
-        d["question_emb"] = question_embedding
-        docs_to_index.append(d)
-        print(idx)
-    document_store.write_documents(docs_to_index)
+    # Index to ES
+    if document_store.get_document_count() == 0:
+        docs_to_index = []
+        for idx, row in df.iterrows():
+            d = row.to_dict()
+            d = {k: v.strip() for k, v in d.items()}
+            d["document_id"] = idx
+            # add embedding
+            question_embedding = retriever.create_embedding(row["question"])
+            d["question_emb"] = question_embedding
+            docs_to_index.append(d)
+            print(idx)
+        document_store.write_documents(docs_to_index)
 
 
-# Init reader & and use Finder to get answer
-finder = Finder(reader=None, retriever=retriever)
-prediction = finder.get_answers_via_similar_questions(question="How high is mortality?", top_k_retriever=10)
-for p in prediction["answers"]:
-    print(p["question"])
+def update_embeddings(document_store, retriever):
+    #TODO move this upstream into haystack
+    body = {
+        "size": 10000,
+        "query": {
+        "match_all": {}
+    },
+    "_source": {"includes":["question"]}
+
+}
+    results = document_store.client.search(index=document_store.index, body=body, )["hits"]["hits"]
+    # update embedding field
+    for r in results:
+        question_embedding = retriever.create_embedding(r["_source"]["question"])
+
+        body = {
+        "doc" : {
+            "question_emb": question_embedding
+        }
+    }
+        document_store.client.update(index=document_store.index, id=r["_id"], body=body)
+
+
+if __name__=="__main__":
+
+    document_store = ElasticsearchDocumentStore(
+        host="localhost",
+        username="",
+        password="",
+        index="document",
+        text_field="answer",
+        embedding_field="question_emb",
+        embedding_dim=768,
+        excluded_meta_data=["question_emb"],
+    )
+
+    MODEL = "deepset/sentence_bert"
+    GPU = False
+
+    retriever = ElasticsearchRetriever(document_store=document_store, embedding_model=MODEL, gpu=GPU,
+                                       emb_extraction_layer=-2, pooling_strategy="reduce_mean")
+
+    # index new docs
+    # index_new_docs(document_store, retriever)
+
+    # or just update embeddings
+    update_embeddings(document_store, retriever)
+
+    # test with a query
+    finder = Finder(reader=None, retriever=retriever)
+    prediction = finder.get_answers_via_similar_questions(question="How high is mortality?", top_k_retriever=10)
+    for p in prediction["answers"]:
+        print(p["question"])


### PR DESCRIPTION
- Add option to update emdeddings in existing elasticsearch index (e.g. for changing to new model)
- Update some defaults in API config
- Add basic separation of models for different languages (english => sentence-bert, rest => BM25 via elasticsearch)

The last one is quite hacky in order to get it done for this hackthon. 

- Requests to http://localhost:8000/models/1/faq-qa => multilingual 
- Requests to http://localhost:8000/models/2/faq-qa => english

We should change that to proper locals like "en" / "de" ...
 