### PR TITLE
Added language detection in backend

### DIFF
--- a/covid_nlp/language/detect_language.py
+++ b/covid_nlp/language/detect_language.py
@@ -3,7 +3,7 @@ import cld3 # requires protobuf
 import pycld2 as cld2
 
 class LanguageDetector():
-    def __init__(self, version = 3):
+    def __init__(self, version = 2):
         self.version = version
 
     def detect_lang_cld2(self, text):


### PR DESCRIPTION
The questions are classified according to their language. If questions are english, they're sent to model 2, otherwise they're sent to model 1 (general model).

I evaluated [CLD2](https://github.com/aboSamoor/pycld2), [CLD3](https://github.com/bsolomon1124/pycld3) and [LangID](https://github.com/saffsd/langid.py) for language detection. 

CLD2 was by far the best on our questions (accuracy: 98.1%, macro f1: 81.7%, f1 for 'en': 99.06%).