### PR TITLE
Add filter for en model. Make cld3 an optional requirement

### DIFF
--- a/backend/controller/model.py
+++ b/backend/controller/model.py
@@ -87,7 +87,6 @@ else:
     # don't need one for pure FAQ matching
     reader = None
 
-# TODO we should switch this later to use "en" / "de" etc in the endpoint than plain model ids
 FINDERS = {1: Finder(reader=reader, retriever=retriever),
            2: Finder(reader=reader, retriever=english_retriever)}
 
@@ -164,8 +163,7 @@ class Response(BaseModel):
 # CURL example: curl --request POST --url 'http://127.0.0.1:8000/question/ask' --data '{"questions": ["Who is the father of Arya Starck?"]}'
 @router.post("/question/ask", response_model=Response, response_model_exclude_unset=True)
 def ask(request: Query):
-    # todo provide some logic to determin the model, e.g. language, is it FAQ or QA etc.
-
+    # detect language & route request to related model
     lang_detector = LanguageDetector()
     english_question_count = 0
     # count number of english question
@@ -175,6 +173,7 @@ def ask(request: Query):
 
     # if majority of questions is english, send questions to english model
     if english_question_count > int(len(request.questions) / 2):
+        request.filters["lang"] = "en"
         return ask_faq(2, request)
     # send questions to general model
     else:

--- a/covid_nlp/language/detect_language.py
+++ b/covid_nlp/language/detect_language.py
@@ -1,5 +1,4 @@
 import sys
-import cld3 # requires protobuf
 import pycld2 as cld2
 
 class LanguageDetector():
@@ -11,6 +10,7 @@ class LanguageDetector():
         return pred[1], float(pred[2])
 
     def detect_lang_cld3(self, text):
+        import cld3  # requires protobuf
         pred = cld3.get_language(text)
         return pred.language, 100*pred.probability
 
@@ -21,6 +21,7 @@ class LanguageDetector():
             return self.detect_lang_cld3(text)
 
     def detect_freq_lang(self, text, n = 3):
+        import cld3  # requires protobuf
         pred = cld3.get_frequent_languages(text, num_langs = n)
         pred_list = [ (p.language, 100*p.probability) for p in pred ]
         return pred_list

--- a/covid_nlp/language/requirements.txt
+++ b/covid_nlp/language/requirements.txt
@@ -1,3 +1,3 @@
 pandas
-cld2
+pycld2
 pycld3


### PR DESCRIPTION
- When we forward a request from the generic endpoint to the English model we should also add a filter to only focus on English FAQs.
- requirements for language detection caused some issues during installation. fixed it for cld2 and made cld3 optional as we don't use it in the deployment