### PR TITLE
Add model_id in response

### DIFF
--- a/backend/controller/model.py
+++ b/backend/controller/model.py
@@ -118,6 +118,7 @@ class Answer(BaseModel):
 class ResponseToIndividualQuestion(BaseModel):
     question: str
     answers: List[Optional[Answer]]
+    model_id: int
 
 
 class Response(BaseModel):
@@ -201,6 +202,7 @@ def ask_faq(model_id: int, request: Query):
         result = finder.get_answers_via_similar_questions(
             question=question, top_k_retriever=request.top_k_retriever, filters=request.filters,
         )
+        result["model_id"] = model_id
         results.append(result)
 
         elasticapm.set_custom_context({"results": results})


### PR DESCRIPTION
With the new unified QA endpoint, the `model_id` to use is no longer explicit in the request. However, the `model_id` is needed for the feedback endpoint.

This PR adds `model_id` in the response body.