### PR TITLE
Update Arbeitsagentur scraper to match new site

### DIFF
--- a/datasources/scrapers/Arbeitsagentur_scraper.py
+++ b/datasources/scrapers/Arbeitsagentur_scraper.py
@@ -30,10 +30,10 @@ class CovidScraper(scrapy.Spider):
 
         all_nodes = response.xpath("//*")
         for node in all_nodes:
-            if node.attrib.get("class") == "ba-content-article":
+            if node.attrib.get("class") == "ba-content-row":
                 ba_content_article_count += 1
-                # end of FAQ
-                if ba_content_article_count == 2:
+                # end of FAQ 
+                if ba_content_article_count == 4:
                     break
 
             # in question


### PR DESCRIPTION
Hey, Arbeitsagentur changed their website's format. This change gets all the QA data. Previous runs of the scraper would pick up non QA data.