### PR TITLE
PR_1 tfidf_client train

### DIFF
--- a/covid_nlp/modeling/tfidf/tfidf_client.py
+++ b/covid_nlp/modeling/tfidf/tfidf_client.py
@@ -17,8 +17,8 @@ from eval import eval_question_similarity
 
 
 class TfidfEvaluator():
-    def __init__(self):
-        self.model = TfidfTrainer(instream = "dummy")
+    def __init__(self, trainer):
+        self.model = trainer
         self.model.load_model()
 
     def process_string(self, mystring):
@@ -37,8 +37,13 @@ class TfidfEvaluator():
         cos_sim = cosine_similarity(vec1, vec2)
         return cos_sim[0][0]
 
+
+# main() is modified to initialize a trainer object first and 
+# pass it as a param into TfidfEvaluator() to initialize a evaluator
+
 def main():
-    evaluator = TfidfEvaluator()
+    trainer = TfidfTrainer(instream="dummy")
+    evaluator = TfidfEvaluator(trainer)
 
     eval_file = "../../../data/eval_question_similarity_en.csv"
     df = pd.read_csv(eval_file)

--- a/covid_nlp/modeling/tfidf/tfidf_train.py
+++ b/covid_nlp/modeling/tfidf/tfidf_train.py
@@ -11,8 +11,8 @@ from preprocess import Preprocessor
 
 class TfidfTrainer():
 
-    def __init__(self, instream = None):
-        self.preprocessor = Preprocessor(instream = instream)
+    def __init__(self, preprocessor):
+        self.preprocessor = preprocessor
         self.feature_vectors = None
         self.vectorizer = None
 
@@ -44,11 +44,17 @@ class TfidfTrainer():
             self.vectorizer = pickle.load(infile)
 
 
+# main() is modified to initialize a Preprocessor outside the TfidfTrainer()
+# and pass a preprocessor into TfidfTrainer() as a param
+
 def main():
-    trainer = TfidfTrainer()
+
+    instream = None
+    preprocessor = Preprocessor(instream = instream)
+    trainer = TfidfTrainer(preprocessor)
     corpus = trainer.preprocess_corpus()
     trainer.train_model(corpus)
     trainer.save_model()
- 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Two classes`TfidfTrainer()` and `TfidfEvaluator()` 's `__init__()`are changed to receive objects from outside the class instead of initializing objects inside class. For example, for `TfidfEvaluator()`, when to initialize its object in `main()`, a object of `preprocessor` will be initialized first and passed into `TfidfEvaluator()`'s `__init()__` as a parameter, as the following shows. And the similar changes are made to classes`TfidfTrainer()` as well.